### PR TITLE
Feature/Docker-Mysql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# vscode setting file
+.DS_Store
+db/.DS_Store

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,0 +1,5 @@
+# FROM mysql/mysql-server:latest
+FROM mysql:latest
+
+# 권한 문제로 인한 sql 초기세팅 error 해결
+CMD "chmod 755 ./mysql-init-file/init.sql"

--- a/db/mysql-init-file/init.sql
+++ b/db/mysql-init-file/init.sql
@@ -1,0 +1,12 @@
+create user 'root'@'%' identified with mysql_native_password by 'password';
+grant all privileges on *.* to 'root'@'%';
+flush privileges;
+
+CREATE DATABASE test;
+use test;
+
+-- create table user (
+--     id int(10) not null auto_increment,
+--     name varchar(20),
+--     constraint user_pk primary key(id)
+-- );

--- a/db/mysql-init-file/init.sql
+++ b/db/mysql-init-file/init.sql
@@ -1,5 +1,5 @@
-create user 'root'@'%' identified with mysql_native_password by 'password';
-grant all privileges on *.* to 'root'@'%';
+create user 'test'@'%' identified with mysql_native_password by 'password';
+grant all privileges on *.* to 'test'@'%';
 flush privileges;
 
 CREATE DATABASE test;

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -9,8 +9,7 @@ services:
     platform: linux/amd64
     command: mysqld --default-authentication-plugin=mysql_native_password
     environment:
-      MYSQL_DATABASE: test
-      MYSQL_ROOT_PASSWORD: root
+      MYSQL_ROOT_PASSWORD: password
     ports:
       - "3306:3306"
     volumes:

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,0 +1,19 @@
+version: "3.7"
+
+services:
+  db:
+    container_name: mysql
+    build: 
+      context: ./db
+      dockerfile: Dockerfile
+    platform: linux/amd64
+    command: mysqld --default-authentication-plugin=mysql_native_password
+    environment:
+      MYSQL_DATABASE: test
+      MYSQL_ROOT_PASSWORD: root
+    ports:
+      - "3306:3306"
+    volumes:
+      # init.sql로 db 초기화
+      - ./db/mysql-init-file:/docker-entrypoint-initdb.d/:ro
+      - ./db/data:/var/lib/mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.7"
+
+services:
+  db:
+    container_name: mysql
+    build: 
+      context: ./db
+      dockerfile: Dockerfile
+    platform: linux/amd64
+    command: mysqld --default-authentication-plugin=mysql_native_password
+    environment:
+      MYSQL_DATABASE: test
+      MYSQL_ROOT_PASSWORD: root
+    ports:
+      - "3306:3306"
+    volumes:
+      # init.sql로 db 초기화
+      - ./db/mysql-init-file:/docker-entrypoint-initdb.d/:ro
+      - ./db/data:/var/lib/mysql
+    networks:
+      - app-tier
+    
+  backend:
+    container_name: backend
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+    links:
+      - db
+    restart: on-failure
+    networks:
+      - app-tier
+    
+
+networks:
+  app-tier:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,7 @@ services:
     platform: linux/amd64
     command: mysqld --default-authentication-plugin=mysql_native_password
     environment:
-      MYSQL_DATABASE: test
-      MYSQL_ROOT_PASSWORD: root
+      MYSQL_ROOT_PASSWORD: password
     ports:
       - "3306:3306"
     volumes:


### PR DESCRIPTION
backend의 폴더구조를 먼저 세팅하셔야 합니다. ->  https://github.com/Techeer-TeamC/backend/pull/10

backend와 mysql을 연동한 dockerizing을 구현하였습니다.

test 방법
<img width="417" alt="image" src="https://user-images.githubusercontent.com/33611439/163672378-51423bf7-d35b-47df-b7fc-b02d2f4b46b4.png">
1. resources/application.property 수정
1-1. Docker build의 경우
- resources/application.property 파일의  ip를 db(= docker container name)로 수정 (위 사진과 같은 형태이면 됩니다)
- cd backend 이동 후, ./gradlew assemble을 통해 jar 파일 생성
- 최상위 폴더로 돌아와서, docker-compose up --build 실행

1-2. local의 경우
- resources/application.property 파일의 ip를 localhost로 수정
- docker-compose -f docker-compose-local.yml up --build 실행
<img width="1074" alt="image" src="https://user-images.githubusercontent.com/33611439/163673204-3fa59d18-3a35-4133-a541-9a4110d18bc8.png">

- 위와 같이 mysql setting이 끝난 경우, spring boot 실행

2. swagger를 통해 접속 확인
- localhost:8080/swagger-ui/  접속
<img width="1415" alt="image" src="https://user-images.githubusercontent.com/33611439/163673269-30cd6997-a60b-4272-bc5d-034fc80afe5f.png">
- 위와 같이 test api인 allUser를 실행했을 때 200 code 확인

(빈 리스트가 나오는 이유는 user table에 sample data를 넣지 않아서 그렇습니다.)

